### PR TITLE
use M::I modules

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -10,7 +10,6 @@ inc/Module/Install/Makefile.pm
 inc/Module/Install/Metadata.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
-inc/parent.pm
 inc/PerlIO.pm
 inc/Sub/Uplevel.pm
 inc/Test/Builder.pm
@@ -44,6 +43,8 @@ lib/Data/ObjectDriver/SQL/Oracle.pm
 Makefile.PL
 MANIFEST			This list of files
 META.yml
+MYMETA.json
+MYMETA.yml
 README
 t/00-compile.t
 t/01-col-inheritance.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,8 @@
 # $Id$
 
 use inc::Module::Install;
+use Module::Install::GithubMeta;
+use Module::Install::AuthorTests;
 
 name('Data-ObjectDriver');
 abstract('');
@@ -11,6 +13,7 @@ no_index(directory => 't');
 
 include('ExtUtils::AutoInstall');
 
+
 requires('DBI');
 requires('Class::Accessor::Fast');
 requires('Class::Data::Inheritable');
@@ -19,7 +22,7 @@ requires('List::Util');
 recommends('Text::SimpleTable');
 build_requires('Test::Exception');
 
-githubmeta;
+githubmeta();
 
 # Cache::Memory isn't in Debian, and the tests all SKIP if this isn't here anyway,
 # so it's more of a build_recommends than a build_requires, but that doesn't exist,


### PR DESCRIPTION
Hello

I am no M::I user, but it seems weird to have `perl Makefile.PL` in the raw repository to complain about missing modules, and not saying which. Probably there is a cleaner approach, but after talking with some people in IRC this seemed the more simple approach (just two dependencies).

Best,
Alberto