### PR TITLE
Fix test

### DIFF
--- a/lib/Data/ObjectDriver/Driver/DBD/SQLite.pm
+++ b/lib/Data/ObjectDriver/Driver/DBD/SQLite.pm
@@ -30,7 +30,8 @@ sub bind_param_attributes {
 sub map_error_code {
     my $dbd = shift;
     my($code, $msg) = @_;
-    if ($msg && $msg =~ /not unique/) {
+
+    if ($msg && $msg =~ /(?:not unique|UNIQUE constraint failed)/) {
         return Data::ObjectDriver::Errors->UNIQUE_CONSTRAINT;
     } else {
         return;

--- a/t/06-errors.t
+++ b/t/06-errors.t
@@ -29,6 +29,8 @@ $t = ErrorTest->new;
 $t->foo('bar');
 dies_ok { $t->insert } 'Second insert fails';
 
-is(ErrorTest->driver->last_error, Data::ObjectDriver::Errors->UNIQUE_CONSTRAINT, 'Failed because of a unique constraint');
+is(ErrorTest->driver->last_error,
+   Data::ObjectDriver::Errors->UNIQUE_CONSTRAINT,
+   'Failed because of a unique constraint');
 
 sub DESTROY { teardown_dbs(qw( global )); }


### PR DESCRIPTION
The test was failing because the error message from DBD changed. To keep backwards compatibility changed the regular expression to match both error messages.

Best,
Alberto