### PR TITLE
Change the closing timing of $sth when inserting/creating records.

### DIFF
--- a/lib/Data/ObjectDriver/Driver/DBI.pm
+++ b/lib/Data/ObjectDriver/Driver/DBI.pm
@@ -395,8 +395,6 @@ sub _insert_or_replace {
     }
     eval { $sth->execute };
 	die "Failed to execute $sql with ".join(", ",@$cols).": $@" if $@;
-    _close_sth($sth);
-    $driver->end_query($sth);
 
     ## Now, if we didn't have an object ID, we need to grab the
     ## newly-assigned ID.
@@ -409,6 +407,9 @@ sub _insert_or_replace {
         ## the original object.
         $orig_obj->$id_col($id);
     }
+
+    $driver->end_query($sth);
+    _close_sth($sth);
 
     $obj->call_trigger('post_save', $orig_obj);
     $obj->call_trigger('post_insert', $orig_obj);


### PR DESCRIPTION
$sth cannot be used in $dbd->fetch_id.
https://github.com/sixapart/data-objectdriver/blob/0.11/lib/Data/ObjectDriver/Driver/DBI.pm#L406

$sth is closed before calling $dbd->fetch_id.
https://github.com/sixapart/data-objectdriver/blob/0.11/lib/Data/ObjectDriver/Driver/DBI.pm#L398

I want to change the closing timing of $sth.