### PR TITLE
Fix failed tests with Perl 5.25.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 !LICENSE
 /cpanfile.snapshot
 /local
+/*.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
+  - "5.22"
+  - "5.24"
 before_install:
   - cpanm -n DBD::SQLite Devel::Cover::Report::Coveralls
 script:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Fix failed tests with Perl 5.25.11 (miniuchi) #24
+
 0.14 2016-01-14T03:03:02Z
 
     - Fix test for SQLite 3.10 compatibility (ziguzagu) #21

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "-2006"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.0.1, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Minilla/v3.0.10, CPAN::Meta::Converter version 2.150005",
    "license" : [
       "artistic_2"
    ],
@@ -79,7 +79,7 @@
          "web" : "https://github.com/sixapart/data-objectdriver"
       }
    },
-   "version" : "0.14",
+   "version" : "0.15",
    "x_authority" : "cpan:SIXAPART",
    "x_contributors" : [
       "Mart Atkins <matkins@sixapart.com>",
@@ -103,7 +103,8 @@
       "ambs <ambs@cpan.org>",
       "David Steinbrunner <dsteinbrunner@pobox.com>",
       "Akira Sawada <akira@peatix.com>",
-      "Masahiro Iuchi <miuchi@sixapart.com>",
-      "ziguzagu <ziguzagu@gmail.com>"
-   ]
+      "ziguzagu <ziguzagu@gmail.com>",
+      "Masahiro Iuchi <miuchi@sixapart.com>"
+   ],
+   "x_serialization_backend" : "JSON::PP version 2.27300_01"
 }

--- a/lib/Data/ObjectDriver.pm
+++ b/lib/Data/ObjectDriver.pm
@@ -11,7 +11,7 @@ use Data::ObjectDriver::Iterator;
 
 __PACKAGE__->mk_accessors(qw( pk_generator txn_active ));
 
-our $VERSION = '0.14';
+our $VERSION = '0.15';
 our $DEBUG = $ENV{DOD_DEBUG} || 0;
 our $PROFILE = $ENV{DOD_PROFILE} || 0;
 our $PROFILER;

--- a/t/01-col-inheritance.t
+++ b/t/01-col-inheritance.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 unless (eval { require DBD::SQLite }) {

--- a/t/02-basic.t
+++ b/t/02-basic.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/03-primary-keys.t
+++ b/t/03-primary-keys.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/04-clone.t
+++ b/t/04-clone.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/05-deflate.t
+++ b/t/05-deflate.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/06-errors.t
+++ b/t/06-errors.t
@@ -3,7 +3,7 @@
 use strict;
 
 use lib 't/lib';
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/07-has-a-cached.t
+++ b/t/07-has-a-cached.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/07-has-a.t
+++ b/t/07-has-a.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/08-iterator.t
+++ b/t/08-iterator.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/09-resultset.t
+++ b/t/09-resultset.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 $Data::ObjectDriver::DEBUG = 0;
 use Test::More;

--- a/t/10-resultset-peek.t
+++ b/t/10-resultset-peek.t
@@ -7,7 +7,7 @@ use strict;
 
 use lib 't/lib';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 $Data::ObjectDriver::DEBUG = 0;
 use Test::More;

--- a/t/12-windows.t
+++ b/t/12-windows.t
@@ -6,7 +6,7 @@ use Data::Dumper;
 use lib 't/lib';
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;

--- a/t/20-driver-sqlite.t
+++ b/t/20-driver-sqlite.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 $Data::ObjectDriver::DEBUG = 0;
 use Test::More;

--- a/t/31-cached.t
+++ b/t/31-cached.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';  # for Cache::Memory substitute.
 use lib 't/lib/cached';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 BEGIN {
@@ -187,6 +187,6 @@ ok(! Ingredient->lookup(1), "really deleted");
 is($recipe->remove, 1, 'Recipe removed successfully');
 is($recipe2->remove, 1, 'Recipe removed successfully');
 
-require 't/txn-common.pl';
+require './t/txn-common.pl';
 
 sub DESTROY { teardown_dbs(qw( global )); }

--- a/t/32-partitioned.t
+++ b/t/32-partitioned.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib/partitioned';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 unless (eval { require DBD::SQLite }) {
@@ -123,6 +123,6 @@ is $ingredient3->remove, 1, 'Ingredient removed successfully';
 is $recipe->remove, 1, 'Recipe removed successfully';
 is $recipe2->remove, 1, 'Recipe removed successfully';
 
-require 't/txn-common.pl';
+require './t/txn-common.pl';
 
 sub DESTROY { teardown_dbs(qw( global cluster1 cluster2 )); }

--- a/t/33-views.t
+++ b/t/33-views.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib/views';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 BEGIN {

--- a/t/34-both.t
+++ b/t/34-both.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/both';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;
@@ -186,6 +186,6 @@ $replaced = Recipe->lookup($rid);
 ok $replaced->{__cached};
 is $replaced->title, 'Cup Cake';
 
-require 't/txn-common.pl';
+require './t/txn-common.pl';
 
 sub DESTROY { teardown_dbs(qw( global cluster1 cluster2 )); }

--- a/t/35-multiplexed.t
+++ b/t/35-multiplexed.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib/multiplexed';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::Exception;
 use Test::More;

--- a/t/41-callbacks.t
+++ b/t/41-callbacks.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 unless (eval { require DBD::SQLite }) {

--- a/t/42-callbacks-multi-pk.t
+++ b/t/42-callbacks-multi-pk.t
@@ -4,7 +4,7 @@ use strict;
 
 use lib 't/lib/partitioned';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 unless (eval { require DBD::SQLite }) {

--- a/t/50-profiling.t
+++ b/t/50-profiling.t
@@ -5,7 +5,7 @@ use strict;
 use lib 't/lib';
 use lib 't/lib/both';
 
-require 't/lib/db-common.pl';
+require './t/lib/db-common.pl';
 
 use Test::More;
 use Test::Exception;


### PR DESCRIPTION
#23 

Fix tests for Perl 5.25.11 or newer ('.' in @INC is removed).
