### PR TITLE
Add disconnect method explicitly to pass tests for windows

### DIFF
--- a/t/09-resultset.t
+++ b/t/09-resultset.t
@@ -173,4 +173,5 @@ $result->rewind;
     diag "calling next() after add_term() with 'op'" . $result->next; ## this should return the object which has "rating == 3".
 }
 
+$wine->driver->dbh->disconnect;
 teardown_dbs(qw( global ));

--- a/t/10-resultset-peek.t
+++ b/t/10-resultset-peek.t
@@ -147,4 +147,5 @@ is $result->peek_next->name, 'Stags Leap', 'the next one will be Stags Leap';
 is $result->next->name, 'Stags Leap';
 ok ! $result->peek_next, "Stags Leap was the last one";
 
+$wine->driver->dbh->disconnect;
 teardown_dbs(qw( global ));

--- a/t/12-windows.t
+++ b/t/12-windows.t
@@ -99,6 +99,8 @@ ok( !$iter->(), "No third row; limit argument respected" );
 is( $load_count, 2, "2 objects loaded; limit argument respected");
 $iter->end;
 
+$r->driver->dbh->disconnect;
+$i->driver->dbh->disconnect;
 teardown_dbs(qw( global ));
 
 print Dumper( Data::ObjectDriver->profiler->query_log ) if $ENV{DOD_PROFILE};

--- a/t/35-multiplexed.t
+++ b/t/35-multiplexed.t
@@ -139,4 +139,7 @@ sub _check_object {
     is $obj2->recipe_id, $obj->recipe_id;
 }
 
+for my $driver (@{ Ingredient2Recipe->driver->drivers }) {
+    $driver->dbh->disconnect;
+}
 teardown_dbs(qw( global1 global2 ));


### PR DESCRIPTION
I confirmed ```All tests successful.``` on Strawberry Perl 5.18.4 under Windows 7(32bit).
 