### PR TITLE
Attempt to make D:OD fork safe

### DIFF
--- a/lib/Data/ObjectDriver/Driver/DBI.pm
+++ b/lib/Data/ObjectDriver/Driver/DBI.pm
@@ -54,7 +54,7 @@ sub init {
                     $dbh->{InactiveDestroy} = 1;
                     $driver_weaken->dbh(undef);
                 }
-                $driver->txn_active(0);
+                $driver_weaken->txn_active(0);
             };
         });
     }


### PR DESCRIPTION
This commit add these functions to D:OD, when forked;

 - Reset all transaction status in child process
 - Destroy and forget all cached DBI handles safely

notes:
 - Works only when POSIX::AtFork was found
 - Basic logic was taken from Cache::Memcached::Fast::Safe, and some are
 taken from Teng/DBIx::Skinny


Disclaimer:
  - Tested only on OSX / Ubuntu with SQLite and MySQL.
  - I don't know ( forgot? :) ) how to write tests using real mysql instance for D:OD... test which I used is here https://gist.github.com/aklaswad/edf8659d876b082e8c18ca4619f4e909  