### PR TITLE
Also use "($term)" at _parse_array_terms (inside add_complex_where).

### DIFF
--- a/lib/Data/ObjectDriver/SQL.pm
+++ b/lib/Data/ObjectDriver/SQL.pm
@@ -186,7 +186,7 @@ sub _parse_array_terms {
             foreach my $t2 ( keys %$t ) {
                 my ($term, $bind, $col) = $stmt->_mk_term($t2, $t->{$t2});
                 $stmt->where_values->{$col} = $t->{$t2};
-                push @out, $term;
+                push @out, "($term)";
                 push @bind, @$bind;
             }
             $out .= '(' . join(" AND ", @out) . ")";

--- a/t/11-sql.t
+++ b/t/11-sql.t
@@ -3,7 +3,7 @@
 use strict;
 
 use Data::ObjectDriver::SQL;
-use Test::More tests => 96;
+use Test::More tests => 95;
 
 my $stmt = ns();
 ok($stmt, 'Created SQL object');

--- a/t/11-sql.t
+++ b/t/11-sql.t
@@ -3,7 +3,7 @@
 use strict;
 
 use Data::ObjectDriver::SQL;
-use Test::More tests => 93;
+use Test::More tests => 96;
 
 my $stmt = ns();
 ok($stmt, 'Created SQL object');
@@ -311,5 +311,32 @@ is($stmt->as_sql, "SELECT foo\nFROM baz\n-- bad", "correctly untainted");
 
 $stmt->comment("G\\G");
 is($stmt->as_sql, "SELECT foo\nFROM baz\n-- G", "correctly untainted");
+
+## Testing complex WHERE
+$stmt = ns();
+$stmt->add_complex_where([
+    { foo => 'foo_value' },
+    { bar => 'bar_value' },
+]);
+is($stmt->as_sql_where, "WHERE ((foo = ?)) AND ((bar = ?))\n");
+
+$stmt = ns();
+my @terms = (
+    { foo => 'foo_value' },
+    {
+        bar => [
+            { op => 'LIKE', value => 'bar1%' },
+            { op => 'LIKE', value => 'bar2%' },
+        ],
+        baz => 'baz_value',
+    }
+);
+$stmt->add_complex_where(\@terms);
+is(
+    $stmt->as_sql_where,
+    (keys(%{$terms[1]}))[0] eq 'bar'
+        ?  "WHERE ((foo = ?)) AND (((bar LIKE ?) OR (bar LIKE ?)) AND (baz = ?))\n"
+        :  "WHERE ((foo = ?)) AND ((baz = ?) AND ((bar LIKE ?) OR (bar LIKE ?)))\n"
+);
 
 sub ns { Data::ObjectDriver::SQL->new }


### PR DESCRIPTION
#30

We should handle a return value of `$stmt->_mk_term` as a group.
The statement "($term)" has also been used in these method.
* [add_where](https://github.com/sixapart/data-objectdriver/blob/42d15468c091252d1a3ceaaa433f916360a298b3/lib/Data/ObjectDriver/SQL.pm#L156)
* [add_having](https://github.com/sixapart/data-objectdriver/blob/42d15468c091252d1a3ceaaa433f916360a298b3/lib/Data/ObjectDriver/SQL.pm#L223)