### PR TITLE
Clear %Handle cache if dbh is set to undef

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: curl -sL https://git.io/cpm | sudo perl - install -g --with-recommends --with-test --with-configure --show-build-log-on-failure --feature=test_mysql --feature=test_fork
       - name: Run tests
-        run: DOD_TEST_DRIVER=MySQL prove -lr -j4 t
+        run: DOD_TEST_DRIVER=MySQL prove -lr t
 
   mariadb:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: setup mariadb repo
         run: curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
       - name: apt-get
-        run: sudo apt-get update && sudo apt-get install -y libmariadb-dev mariadb-server
+        run: sudo apt-get update && sudo apt-get install -y libmariadb-dev libmariadb-dev-compat mariadb-server
       - name: Install dependencies
         run: curl -sL https://git.io/cpm | sudo perl - install -g --with-recommends --with-test --with-configure --show-build-log-on-failure --feature=test_mariadb --feature=test_fork
       - name: Run tests

--- a/lib/Data/ObjectDriver/Driver/DBI.pm
+++ b/lib/Data/ObjectDriver/Driver/DBI.pm
@@ -23,7 +23,7 @@ sub _is_fork_safe {
     return 1;
 }
 
-__PACKAGE__->mk_accessors(qw( dsn username password connect_options dbh get_dbh dbd prefix reuse_dbh force_no_prepared_cache));
+__PACKAGE__->mk_accessors(qw( dsn username password connect_options get_dbh dbd prefix reuse_dbh force_no_prepared_cache));
 
 
 sub init {
@@ -106,6 +106,18 @@ sub init_db {
     $driver->dbd->init_dbh($dbh);
     $driver->{__dbh_init_by_driver} = 1;
     return $dbh;
+}
+
+sub dbh {
+    my $driver = shift;
+    if (@_) {
+        my $dbh = $driver->{dbh} = shift;
+        if (!$dbh && $driver->reuse_dbh) {
+            $dbh = delete $Handles{$driver->dsn};
+            $dbh->disconnect if $dbh;
+        }
+    }
+    $driver->{dbh};
 }
 
 sub rw_handle {

--- a/lib/Data/ObjectDriver/Driver/DBI.pm
+++ b/lib/Data/ObjectDriver/Driver/DBI.pm
@@ -52,7 +52,7 @@ sub init {
         weaken(my $driver_weaken = $driver);
         POSIX::AtFork->add_to_child(sub {
             return unless $driver_weaken;
-            $driver_weaken->dbh(undef);
+            $driver_weaken->{dbh} = undef;
             %Handles = ();
         });
     }

--- a/t/lib/DodTestUtil.pm
+++ b/t/lib/DodTestUtil.pm
@@ -62,13 +62,13 @@ sub dsn {
     if ( $driver =~ /MySQL|MariaDB/ ) {
         if ( $driver eq 'MariaDB' && !$test_mysqld_dsn ) {
             my $help = `mysql --help`;
-            my ($mariadb_version) = $help =~ /\A.*?([0-9]+\.[0-9]+)\.[0-9]+\-MariaDB/;
+            my ($mariadb_major_version, $mariadb_minor_version) = $help =~ /\A.*?([0-9]+)\.([0-9]+)\.[0-9]+\-MariaDB/;
             no warnings 'redefine';
             $test_mysqld_dsn = \&Test::mysqld::dsn;
             *Test::mysqld::dsn = sub {
                 my $dsn = $test_mysqld_dsn->(@_);
                 # cf. https://github.com/kazuho/p5-test-mysqld/issues/32
-                $dsn =~ s/;user=root// if $mariadb_version && $mariadb_version > 10.3;
+                $dsn =~ s/;user=root// if $mariadb_major_version && $mariadb_major_version >= 10 && $mariadb_minor_version > 3;
                 $dsn;
             };
         }

--- a/t/lib/DodTestUtil.pm
+++ b/t/lib/DodTestUtil.pm
@@ -92,7 +92,12 @@ sub dsn {
         $TestDB{$dbname} ||= Test::mysqld->new(
             my_cnf => {
                 'skip-networking' => '', # no TCP socket
+                'skip-name-resolve' => '',
+                'default_authentication_plugin' => 'mysql_native_password',
                 'sql-mode' => 'TRADITIONAL,NO_AUTO_VALUE_ON_ZERO,ONLY_FULL_GROUP_BY',
+                'bind-address' => '127.0.0.1',
+                'disable-log-bin' => '',
+                'performance_schema' => 'OFF',
             }
         ) or die $Test::mysqld::errstr;
         my $dsn = $TestDB{$dbname}->dsn;

--- a/t/lib/DodTestUtil.pm
+++ b/t/lib/DodTestUtil.pm
@@ -72,6 +72,23 @@ sub dsn {
                 $dsn;
             };
         }
+        if ($driver eq 'MySQL') {
+            *Test::mysqld::wait_for_stop = sub {
+                my $self = shift;
+                local $?;    # waitpid may change this value :/
+                my $ct = 0;
+                # XXX: modified
+                while (waitpid($self->pid, POSIX::WNOHANG()) <= 0) {
+                    sleep 1;
+                    if ($ct++ > 10) {
+                        kill 9, $self->pid;
+                    }
+                }
+                $self->pid(undef);
+                # might remain for example when sending SIGKILL
+                unlink $self->my_cnf->{'pid-file'};
+            };
+        }
         $TestDB{$dbname} ||= Test::mysqld->new(
             my_cnf => {
                 'skip-networking' => '', # no TCP socket


### PR DESCRIPTION
If `$driver->reuse_dbh` is true, there's no way to remove and disconnect a cached dbh. With this, if $driver->dbh is set to undef, the cached dbh is removed and disconnected.