### PR TITLE
Remove __is_stored flag if the object is removed from the database

### DIFF
--- a/lib/Data/ObjectDriver/Driver/DBI.pm
+++ b/lib/Data/ObjectDriver/Driver/DBI.pm
@@ -565,7 +565,7 @@ sub remove {
 
     $obj->call_trigger('post_remove', $orig_obj);
 
-    $orig_obj->{__is_stored} = 1;
+    delete $orig_obj->{__is_stored};
     return $result;
 }
 


### PR DESCRIPTION
Though Data::ObjectDriver does not look at the `__is_stored` flag while saving, it's better to remove the flag after the object is removed from the database because `object_is_stored` is considered to be useful when you determine if the object is being INSERTED or just UPDATED.
 