### PR TITLE
Correct the pod for object_is_stored, which was called is_ephemeral and had the opposite meaning

### DIFF
--- a/lib/Data/ObjectDriver/BaseObject.pm
+++ b/lib/Data/ObjectDriver/BaseObject.pm
@@ -1046,7 +1046,7 @@ are identical.
 
 =head2 C<$obj-E<gt>object_is_stored()>
 
-Returns true if the object hasn't been stored in the database yet.
+Returns true if the object has already been stored in the database.
 This is particularly useful in triggers where you can then determine
 if the object is being INSERTED or just UPDATED.
 


### PR DESCRIPTION
https://github.com/sixapart/data-objectdriver/commit/eb9fc6cf7f4b8404676ea1ca6c97217ac5a87445 was still incomplete. The description of the method also needs a fix.