### PR TITLE
Avoid ram cache to be changed before save

### DIFF
--- a/lib/Data/ObjectDriver/Driver/Cache/RAM.pm
+++ b/lib/Data/ObjectDriver/Driver/Cache/RAM.pm
@@ -30,7 +30,7 @@ sub add_to_cache {
     my $driver = shift;
 
     $driver->start_query('RAMCACHE_ADD ?', \@_);
-    my $ret = $Cache{$_[0]} = $_[1];
+    my $ret = $Cache{$_[0]} = $_[1]->clone;
     $driver->end_query(undef);
 
     return if !defined $ret;
@@ -41,7 +41,7 @@ sub update_cache {
     my $driver = shift;
 
     $driver->start_query('RAMCACHE_SET ?', \@_);
-    my $ret = $Cache{$_[0]} = $_[1];
+    my $ret = $Cache{$_[0]} = $_[1]->clone;
     $driver->end_query(undef);
 
     return if !defined $ret;

--- a/t/31-cached.t
+++ b/t/31-cached.t
@@ -14,7 +14,7 @@ BEGIN {
         plan skip_all => 'Tests require Cache::Memory';
     }
 }
-plan tests => 105;
+plan tests => 106;
 
 setup_dbs({
     global   => [ qw( recipes ingredients ) ],
@@ -184,6 +184,18 @@ ok(! Ingredient->lookup(1), "really deleted");
 
 is($recipe->remove, 1, 'Recipe removed successfully');
 is($recipe2->remove, 1, 'Recipe removed successfully');
+
+# make sure cache is not changed before save
+{
+    my $r = Recipe->new;
+    $r->title('to replace');
+    $r->insert;
+    my $id = $r->recipe_id;
+    my $r1 = Recipe->lookup($id);
+    $r1->title('replaced');
+    my $r2 = Recipe->lookup($id);
+    is $r2->title, 'to replace', 'not replaced yet';
+}
 
 require './t/txn-common.pl';
 

--- a/t/lib/cached/Recipe.pm
+++ b/t/lib/cached/Recipe.pm
@@ -6,14 +6,17 @@ use base qw( Data::ObjectDriver::BaseObject );
 use DodTestUtil;
 
 use Data::ObjectDriver::Driver::DBI;
+use Data::ObjectDriver::Driver::Cache::RAM;
 
 __PACKAGE__->install_properties({
     columns => [ 'recipe_id', 'title' ],
     datasource => 'recipes',
     primary_key => 'recipe_id',
-    driver => Data::ObjectDriver::Driver::DBI->new(
-        dsn      => DodTestUtil::dsn('global'),
-        reuse_dbh => 1,
+    driver      => Data::ObjectDriver::Driver::Cache::RAM->new(
+        fallback => Data::ObjectDriver::Driver::DBI->new(
+            dsn      => DodTestUtil::dsn('global'),
+            reuse_dbh => 1,
+        ),
     ),
 });
 


### PR DESCRIPTION
Using D::OD::Driver::Cache::RAM for Recipe breaks a test at https://github.com/sixapart/data-objectdriver/blob/0.23/t/02-basic.t#L205

Without cache, after $obj->replace is failed, Recipe->lookup gets original columns from DB. However, with RAM cache, It gets the new columns despite the failure because RAM cache stores a reference to the original object.
